### PR TITLE
Forgotten searching improvements

### DIFF
--- a/src/GameServer.java
+++ b/src/GameServer.java
@@ -116,7 +116,7 @@ public class GameServer {
 		if (playerNumber > 0 && this.getNumberOfPlayers() >= playerNumber) {
 			try {
 				//set the timeout for user input
-				//this.clientSocketArray[playerNumber - 1].setSoTimeout(timeOutTime);
+				this.clientSocketArray[playerNumber - 1].setSoTimeout(timeOutTime);
 				BufferedReader in = new BufferedReader(new InputStreamReader(this.clientSocketArray[playerNumber - 1].getInputStream()));
 				String input = in.readLine();
 				System.out.println("Server received message from player " + playerNumber + ": " + input);

--- a/src/QuartoServer.java
+++ b/src/QuartoServer.java
@@ -20,8 +20,8 @@ public class QuartoServer {
 	public static final String GAME_OVER_HEADER = "GAME_OVER: ";
 	public static final String TURN_TIME_LIMIT_HEADER = "TURN_TIME_LIMIT: ";
 
-	//time limit is in milliseconds
-	private static final int TIME_LIMIT_FOR_RESPONSE = 10000;
+	//time limit is in milliseconds (1s)
+	private static final int TIME_LIMIT_FOR_RESPONSE = 1000;  // 10000;
 
 	GameServer gameServer;
 	QuartoBoard quartoBoard;


### PR DESCRIPTION
Added calcNodesInGeneration and calcSearchableDepth methods which are used to determine the depth that we can search at each stage of the game. The calcNodesInGeneration returns the number of UNIQUE nodes, as such we needed a mechanism to ensure that nodes were only examined once per level, I have put in a VERY hacky solution that should be changed. There also seems to be a NullPointerException that happens occasionally near end game (seems to be around 4 moves left), this needs to be investigated further
